### PR TITLE
Fix behavior on unrecognized formats

### DIFF
--- a/snakehump-tests.el
+++ b/snakehump-tests.el
@@ -145,3 +145,8 @@
     (should (equal (snakehump-next "foo_bar_baz"  ) "FooBarBaz"))
     )
 )
+
+(ert-deftest snakehump-unrecognized-formats-return-identity-t ()
+  (should (equal (snakehump-next "42") "42"))
+  (should (equal (snakehump-next "A42") "A42"))
+)

--- a/snakehump.el
+++ b/snakehump.el
@@ -85,7 +85,7 @@
 (defun snakehump-current-format (compound-word)
   "Return a symbol denoting current format"
   (catch 'found
-    (dolist (name snakehump-all-formats found)
+    (dolist (name snakehump-all-formats)
       (if (apply (intern (concat "snakehump-" (symbol-name name) "-p"))
 		 (list compound-word))
 	  (throw 'found name)))))


### PR DESCRIPTION
Currently, snakehump-next-at-point will pick up strings that aren't
found, triggering the evaluation of the unbound return value of
dolist.  It's clearly nicer to return nil and so have no
transformation occur.

BTW, thanks for snakehump!  I recently found it very useful when writing some macros to convert lots of C defines into OCaml constructors; I stumbled into this bug because `FOO_BAR` isn't recognized as a format.  By fixing the issue in this PR, this case happens to work correctly, but I wondered whether the definitions of (at least) snake and dash shouldn't be changed to something like:

```lisp
   (snake t   nil "_"  "^[[:alnum:]]+\\(?:_[[:alnum:]]+\\)+$")
   (dash  t   nil "-"  "^[[:alnum:]]+\\(?:-[[:alnum:]]+\\)+$")
```

I'd be happy to submit a patch with tests if that is of interest to you.